### PR TITLE
Not consider some Exceptions as failure

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -44,6 +44,7 @@
          handler.failure_threshold = 5
          handler.failure_timeout = 5
          handler.invocation_timeout = 10
+         handler.excluded_exceptions = [NotConsideredFailureException]
        end
 
        # Optional

--- a/lib/circuit_breaker/circuit_handler.rb
+++ b/lib/circuit_breaker/circuit_handler.rb
@@ -24,6 +24,11 @@ class CircuitBreaker::CircuitHandler
   attr_accessor :invocation_timeout
 
   #
+  # The exceptions which should be ignored if happens, they are not counted as failures
+  #
+  attr_accessor :excluded_exceptions
+
+  #
   # Optional logger.
   #
   attr_accessor :logger
@@ -31,12 +36,14 @@ class CircuitBreaker::CircuitHandler
   DEFAULT_FAILURE_THRESHOLD  = 5
   DEFAULT_FAILURE_TIMEOUT    = 5
   DEFAULT_INVOCATION_TIMEOUT = 30
+  DEFAULT_EXCLUDED_EXCEPTIONS= []
 
   def initialize(logger = nil)
     @logger = logger
     @failure_threshold = DEFAULT_FAILURE_THRESHOLD
     @failure_timeout = DEFAULT_FAILURE_TIMEOUT
     @invocation_timeout = DEFAULT_INVOCATION_TIMEOUT
+    @excluded_exceptions = DEFAULT_EXCLUDED_EXCEPTIONS
   end
 
   #
@@ -61,8 +68,8 @@ class CircuitBreaker::CircuitHandler
         out = method[*args]
         on_success(circuit_state)
       end
-    rescue Exception
-      on_failure(circuit_state)
+    rescue Exception => e
+      on_failure(circuit_state) unless @excluded_exceptions.include?(e.class)
       raise
     end
     return out


### PR DESCRIPTION
Hi,

I'm trying to use your gem but had a need to not consider some Exceptions as failure, i.e. using ActiveRecord to load a resource I can receive a 404 ResourceNotFoundException which isn't a failure, and shouldn't count as one.

I maked a change in your gem to be possible to pass an array with the exceptions which should not count as failures for circuit breaker.

I hope you can apply this to your gem.

Regards,
Wandenberg
