### PR TITLE
Fix for Ruby 2.1.0

### DIFF
--- a/lib/circuit_breaker/circuit_broken_exception.rb
+++ b/lib/circuit_breaker/circuit_broken_exception.rb
@@ -1,6 +1,6 @@
 class CircuitBreaker::CircuitBrokenException < StandardError
 
-  def initialize(msg, circuit_state = :closed)
+  def initialize(msg = nil, circuit_state = :closed)
     @circuit_state = circuit_state
     super(msg)
   end


### PR DESCRIPTION
This PR fixes the circuit_breaker gem for Ruby 2.1.0 due to changes in Ruby's Timeout built-in.  See commits for details.
