### PR TITLE
keep circuit_state in a thread instead of tan object instance

### DIFF
--- a/lib/circuit_breaker.rb
+++ b/lib/circuit_breaker.rb
@@ -64,7 +64,7 @@ module CircuitBreaker
   # you can have several instances of the same class with different states.
   #
   def circuit_state
-    @circuit_state ||= self.class.circuit_handler.new_circuit_state
+    Thread.current[:"_circuit_state_#{self.class.to_s}"] ||= self.class.circuit_handler.new_circuit_state
   end
 
   module ClassMethods


### PR DESCRIPTION
Hello,

I think the current state of the circuit should be saved in the current thread. This way if the remote service is broken, other instances of the underlying class will not query the service since it will be closed even if another instance closed the circuit.

IMO this is important when using a web framework where the underlying class instance is not reused but recreated on every request.

tests are failing, if there is any interest in this I will write some tests and fix broken tests.

Thanks
