### PR TITLE
use instance methods instead of instance variables

### DIFF
--- a/lib/circuit_breaker/circuit_state.rb
+++ b/lib/circuit_breaker/circuit_state.rb
@@ -48,12 +48,12 @@ class CircuitBreaker::CircuitState
   attr_accessor :failure_count
 
   def increment_failure_count
-    @failure_count = @failure_count + 1
-    @last_failure_time = Time.now
+    self.failure_count = self.failure_count + 1
+    self.last_failure_time = Time.now
   end
 
   def reset_failure_count
-    @failure_count = 0
+    self.failure_count = 0
   end
 
 end


### PR DESCRIPTION
While subclassing this I noticed that this public method is not using methods internally.  This makes it hard to overwrite its interface.

```ruby
class CircuitStateRedis
  def failure_count
    failure_count_redis
  end
end
```