### PR TITLE
remove the aasm dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ An implementation of Michael Nygard's Circuit Breaker pattern.
 
 ## REQUIREMENTS:
 
-circuit_breaker has a dependency on AASM @ http://github.com/rubyist/aasm/tree/master
+None. curcuit_breaker no longer depends on [AASM](http://github.com/rubyist/aasm/tree/master) but will raise AASM::InvalidTransition if that exception is defined.
 
 ## INSTALL:
 

--- a/circuit_breaker.gemspec
+++ b/circuit_breaker.gemspec
@@ -59,8 +59,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = ["History.txt", "README.txt"]
   s.rdoc_options = ["--main", "README.txt", "--charset=UTF-8"]
 
-  s.add_runtime_dependency "aasm"
-
+  s.add_development_dependency "aasm"
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"
 end

--- a/lib/circuit_breaker.rb
+++ b/lib/circuit_breaker.rb
@@ -108,4 +108,5 @@ end
 
 require 'circuit_breaker/circuit_handler'
 require 'circuit_breaker/circuit_broken_exception'
+require 'circuit_breaker/invalid_transition'
 require 'circuit_breaker/circuit_state'

--- a/lib/circuit_breaker/circuit_state.rb
+++ b/lib/circuit_breaker/circuit_state.rb
@@ -1,46 +1,54 @@
-require 'aasm'
-
 #
 # CircuitState is created individually for each object, and keeps
 # track of how the object is doing and whether the object's circuit
 # has tripped or not.
 #
 class CircuitBreaker::CircuitState
+  STATES = %i(open half_open closed)
 
-  include AASM
+  #the state transition map, to: [:from]
+  TRANSITIONS = {
+    open: [:closed, :half_open],
+    half_open: [:open],
+    closed: [:open, :half_open]
+  }
 
-  aasm.state :half_open
-
-  aasm.state :open
-
-  aasm.state :closed, :enter => :reset_failure_count
-
-  aasm.initial_state :closed
-
-  #
-  # Trips the circuit breaker into the open state where it will immediately fail.
-  #
-  aasm.event :trip do
-    transitions :to => :open, :from => [:closed, :half_open]
+  # define #open?, :closed?, :half_open?
+  STATES.each do |state|
+    define_method("#{state}?") do
+      @state == state
+    end
   end
 
-  #
-  # Transitions from an open state to a half_open state.
-  #
-  aasm.event :attempt_reset do
-    transitions :to => :half_open, :from => [:open]
+  def trip
+    raise invalid_transition_exception("trip") unless can_transition_to?(:open)
+    @state = :open
   end
 
-  #
-  # Close the circuit from an open or half open state.
-  #
-  aasm.event :reset do
-    transitions :to => :closed, :from => [:open, :half_open]
+  def trip!
+    trip
+  end
+
+  def attempt_reset
+    raise invalid_transition_exception("attempt_reset") unless can_transition_to?(:half_open)
+    @state = :half_open
+  end
+
+  def reset
+    raise invalid_transition_exception("reset") unless can_transition_to?(:closed)
+    @state = :closed
+    reset_failure_count
+  end
+
+  # if AASM is required elsewhere it will call this method to get current state
+  def aasm(_)
+    OpenStruct.new(current_state: @state)
   end
 
   def initialize()
     @failure_count = 0
     @last_failure_time = nil
+    @state = :closed
   end
 
   attr_accessor :last_failure_time
@@ -56,5 +64,37 @@ class CircuitBreaker::CircuitState
     @failure_count = 0
   end
 
+  private
+
+  attr_reader :state
+
+  def can_transition_to?(to_state)
+    TRANSITIONS[to_state].include?(state)
+  end
+
+  def invalid_transition_exception(event_name)
+    invalid_transition_exception_class.new(self, event_name, "circuit_state")
+  end
+
+  def invalid_transition_exception_class
+    aasm_exception_defined? ? aasm_exception_class : default_exception_class
+  end
+
+  def aasm_exception_defined?
+    @aasm_exception_defined ||= begin
+      aasm_exception_class
+      true
+    rescue NameError
+      false
+    end
+  end
+
+  def aasm_exception_class
+    AASM::InvalidTransition
+  end
+
+  def default_exception_class
+    CircuitBreaker::InvalidTransition
+  end
 end
 

--- a/lib/circuit_breaker/invalid_transition.rb
+++ b/lib/circuit_breaker/invalid_transition.rb
@@ -1,0 +1,15 @@
+class CircuitBreaker::InvalidTransition < RuntimeError
+  attr_reader :object, :event_name, :state_machine_name, :failures
+
+  def initialize(object, event_name, state_machine_name, failures = [])
+    @object, @event_name, @state_machine_name, @failures = object, event_name, state_machine_name, failures
+  end
+
+  def message
+    "Event '#{event_name}' cannot transition from '#{object.aasm(state_machine_name).current_state}'. #{reasoning}"
+  end
+
+  def reasoning
+    "Failed callback(s): #{@failures}." unless failures.empty?
+  end
+end

--- a/lib/circuit_breaker/version.rb
+++ b/lib/circuit_breaker/version.rb
@@ -1,3 +1,3 @@
 module CircuitBreaker
-  VERSION = '1.1.2'
+  VERSION = '1.2.0'
 end

--- a/spec/circuit_breaker_spec.rb
+++ b/spec/circuit_breaker_spec.rb
@@ -70,9 +70,9 @@ describe CircuitBreaker do
   end
 
   it 'should call second_method and have it run through the circuit breaker' do
-    lambda { @test_object.second_method() }.should raise_error("EPIC FAIL")
-    @test_object.circuit_state.closed?.should == true
-    @test_object.circuit_state.failure_count.should == 1
+    expect { @test_object.second_method() }.to raise_error("EPIC FAIL")
+    expect(@test_object.circuit_state).to be_closed
+    expect(@test_object.circuit_state.failure_count).to eq(1)
   end
 
   it 'should not raise warning about method redefined' do
@@ -82,80 +82,80 @@ describe CircuitBreaker do
     TestClass.circuit_method :second_method
 
     $stderr.rewind
-    $stderr.string.chomp.should_not match(/warning: previous definition of second_method was here/)
+    expect($stderr.string.chomp).to_not match(/warning: previous definition of second_method was here/)
     $stderr = orig_stderr
   end
 
   describe "when closed" do
 
     it "should execute without failing" do
-      @test_object.call_external_method().should == 'hello world!'
-      @test_object.circuit_state.closed?.should == true
-      @test_object.circuit_state.failure_count.should == 0
+      expect(@test_object.call_external_method()).to eq('hello world!')
+      expect(@test_object.circuit_state).to be_closed
+      expect(@test_object.circuit_state.failure_count).to eq(0)
     end
 
     it 'should increment the failure count when a failure occurs' do
       @test_object.fail!
 
-      lambda { @test_object.call_external_method() }.should raise_error
-      @test_object.circuit_state.closed?.should == true
-      @test_object.circuit_state.failure_count.should == 1
+      expect { @test_object.call_external_method() }.to raise_error(RuntimeError)
+      expect(@test_object.circuit_state).to be_closed
+      expect(@test_object.circuit_state.failure_count).to eq(1)
     end
 
     it 'should trip the circuit when too many failures occur' do
       @test_object.fail!
 
-      lambda { @test_object.call_external_method() }.should raise_error
-      lambda { @test_object.call_external_method() }.should raise_error
-      lambda { @test_object.call_external_method() }.should raise_error
-      lambda { @test_object.call_external_method() }.should raise_error
-      lambda { @test_object.call_external_method() }.should raise_error
-      lambda { @test_object.call_external_method() }.should raise_error
+      expect { @test_object.call_external_method() }.to raise_error(RuntimeError)
+      expect { @test_object.call_external_method() }.to raise_error(RuntimeError)
+      expect { @test_object.call_external_method() }.to raise_error(RuntimeError)
+      expect { @test_object.call_external_method() }.to raise_error(RuntimeError)
+      expect { @test_object.call_external_method() }.to raise_error(RuntimeError)
+      expect { @test_object.call_external_method() }.to raise_error(RuntimeError)
 
-      @test_object.circuit_state.open?.should == true
-      @test_object.circuit_state.failure_count.should == 6
+      expect(@test_object.circuit_state).to be_open
+      expect(@test_object.circuit_state.failure_count).to eq(6)
     end
 
     it 'should reset the failure count if closed after a successful call.' do
       @test_object.fail!
 
-      lambda { @test_object.call_external_method() }.should raise_error("FAIL")
+      expect { @test_object.call_external_method() }.to raise_error("FAIL")
 
       @test_object.succeed!
       @test_object.call_external_method()
 
-      @test_object.circuit_state.failure_count.should == 0
-      @test_object.circuit_state.closed?.should == true
+      expect(@test_object.circuit_state.failure_count).to eq(0)
+      expect(@test_object.circuit_state).to be_closed
     end
 
     it 'should trip immediately when the failure threshold is set to zero' do
       @test_object.fail!
 
       TestClass.circuit_handler.failure_threshold = 0
-      lambda { @test_object.call_external_method() }.should raise_error
-      @test_object.circuit_state.open?.should == true
-      @test_object.circuit_state.failure_count.should == 1
+      expect { @test_object.call_external_method() }.to raise_error(RuntimeError)
+      expect(@test_object.circuit_state).to be_open
+      expect(@test_object.circuit_state.failure_count).to eq(1)
     end
 
     it 'should increment the failure count when the method takes too long to return' do
-      lambda { @test_object.unresponsive_method }.should raise_error(CircuitBreaker::CircuitBrokenException)
-      @test_object.circuit_state.closed?.should == true
-      @test_object.circuit_state.failure_count.should == 1
+      expect { @test_object.unresponsive_method }.to raise_error(CircuitBreaker::CircuitBrokenException)
+      expect(@test_object.circuit_state).to be_closed
+      expect(@test_object.circuit_state.failure_count).to eq(1)
     end
 
     describe "and some exceptions not indicates a circuit problem" do
       it 'should not increment the failure count when a failure of a specific type occurs' do
         @test_object.fail!
 
-        lambda { @test_object.raise_specific_error_method }.should raise_error(SpecificException)
-        @test_object.circuit_state.closed?.should == true
-        @test_object.circuit_state.failure_count.should == 1
+        expect { @test_object.raise_specific_error_method }.to raise_error(SpecificException)
+        expect(@test_object.circuit_state).to be_closed
+        expect(@test_object.circuit_state.failure_count).to eq(1)
 
         @test_object.succeed!
 
-        lambda { @test_object.raise_specific_error_method }.should raise_error(NotFoundException)
-        @test_object.circuit_state.closed?.should == true
-        @test_object.circuit_state.failure_count.should == 1
+        expect { @test_object.raise_specific_error_method }.to raise_error(NotFoundException)
+        expect(@test_object.circuit_state).to be_closed
+        expect(@test_object.circuit_state.failure_count).to eq(1)
       end
     end
 
@@ -170,11 +170,11 @@ describe CircuitBreaker do
       @test_object.circuit_state.failure_count = 5
 
       # Should return CircuitBrokenException explicitly
-      lambda { @test_object.call_external_method() }.should raise_error(::CircuitBreaker::CircuitBrokenException)
+      expect { @test_object.call_external_method() }.to raise_error(::CircuitBreaker::CircuitBrokenException)
 
       # Failure count should not be open
-      @test_object.circuit_state.failure_count.should == 5
-      @test_object.circuit_state.open?.should == true
+      expect(@test_object.circuit_state.failure_count).to eq(5)
+      expect(@test_object.circuit_state).to be_open
     end
 
     it 'should not reset the circuit when not enough time has passed' do
@@ -185,10 +185,10 @@ describe CircuitBreaker do
       @test_object.circuit_state.last_failure_time = now - failure_threshold
       @test_object.circuit_state.failure_count = 5
 
-      lambda { @test_object.call_external_method() }.should raise_error(::CircuitBreaker::CircuitBrokenException)
+      expect { @test_object.call_external_method() }.to raise_error(::CircuitBreaker::CircuitBrokenException)
 
-      @test_object.circuit_state.failure_count.should == 5
-      @test_object.circuit_state.open?.should == true
+      expect(@test_object.circuit_state.failure_count).to eq(5)
+      expect(@test_object.circuit_state).to be_open
     end
 
   end
@@ -207,8 +207,8 @@ describe CircuitBreaker do
       @test_object.call_external_method()
 
       # After a successful call, the failure count is reset.
-      @test_object.circuit_state.failure_count.should == 0
-      @test_object.circuit_state.closed?.should == true
+      expect(@test_object.circuit_state.failure_count).to eq(0)
+      expect(@test_object.circuit_state).to be_closed
     end
 
     it 'should trip the circuit immediately if in a half open state' do
@@ -223,12 +223,12 @@ describe CircuitBreaker do
 
       # Have an unsuccessful call...
       @test_object.fail!
-      lambda { @test_object.call_external_method() }.should raise_error("FAIL")
+      expect { @test_object.call_external_method() }.to raise_error("FAIL")
 
-      @test_object.circuit_state.failure_count.should == 6
+      expect(@test_object.circuit_state.failure_count).to eq(6)
 
       # The circuit should immediately pop open again.
-      @test_object.circuit_state.open?.should == true
+      expect(@test_object.circuit_state).to be_open
     end
 
   end

--- a/spec/circuit_state_spec.rb
+++ b/spec/circuit_state_spec.rb
@@ -1,0 +1,90 @@
+require 'spec_helper'
+
+describe CircuitBreaker::CircuitState do
+  subject { described_class.new }
+
+  describe "#initialize" do
+    it "sets the state to closed" do
+      expect(subject).to be_closed
+    end
+  end
+
+  shared_examples_for "trip" do
+    it "changes the state from :closed to :open" do
+      subject.trip
+      expect(subject).to be_open
+    end
+
+    it "changes the state from :half_open to :open" do
+      subject.trip
+      subject.attempt_reset
+      subject.trip
+      expect(subject).to be_open
+    end
+
+    it "raises a CircuitBreaker::InvalidTransition exception if invoked from :open" do
+      subject.trip
+      expect { subject.trip }.to raise_error(CircuitBreaker::InvalidTransition)
+    end
+
+    it "raises an AASM::InvalidTransition if AASM is defined" do
+      # fork to require that won't affect the parent process
+      Kernel.fork do
+        require "aasm"
+        subject.trip
+        expect { subject.trip }.to raise_error(AASM::InvalidTransition)
+      end
+    end
+  end
+
+  describe "#trip" do
+    include_examples "trip"
+  end
+
+  describe "#trip!" do
+    include_examples "trip"
+  end
+
+  describe "#attempt_reset" do
+    it "changes the state from :open to :half_open" do
+      subject.trip
+      subject.attempt_reset
+      expect(subject).to be_half_open
+    end
+
+    it "raises an exception if invoked from :half_open" do
+      subject.trip
+      subject.attempt_reset
+      expect { subject.attempt_reset }.to raise_error(CircuitBreaker::InvalidTransition)
+    end
+
+    it "raises an exception if invoked from :closed" do
+      expect { subject.attempt_reset }.to raise_error(CircuitBreaker::InvalidTransition)
+    end
+  end
+
+  describe "#reset" do
+    it "changes the state from :open to :closed" do
+      subject.trip
+      subject.reset
+      expect(subject).to be_closed
+    end
+
+    it "changes the state from :half_open to :closed" do
+      subject.trip
+      subject.attempt_reset
+      subject.reset
+      expect(subject).to be_closed
+    end
+
+    it "raises an exception if invoked from :closed" do
+      expect { subject.reset }.to raise_error(CircuitBreaker::InvalidTransition)
+    end
+
+    it "resets the failure count" do
+      subject.trip
+      subject.reset
+      expect(subject.failure_count).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
Hi,
first of all, thanks for the gem! I've noticed there was an issue open about AASM being the single dependency and how nice it would be to have none.
So I went ahead and removed it - the circuit_breaker doesn't have a lot of states or complex transitions, nor does it require a lot of callbacks or saving state via ActiveRecord.

I've kept the backwards compatibility by raising AASM::InvalidTransition if that exception is defined, but the check is cached, not sure if that affects performance.

Other than that, rspec was throwing a lot of warnings about the .should syntax so I went ahead and updated those to expect(..).

Thanks for taking a look!
