### PR TITLE
Change circuit state initializer for use with ClassMethods

### DIFF
--- a/lib/circuit_breaker.rb
+++ b/lib/circuit_breaker.rb
@@ -64,7 +64,7 @@ module CircuitBreaker
   # you can have several instances of the same class with different states.
   #
   def circuit_state
-    @circuit_state ||= self.class.circuit_handler.new_circuit_state
+    @circuit_state ||= CircuitBreaker::CircuitState.new
   end
 
   module ClassMethods


### PR DESCRIPTION
This is all to the best of my understanding from poking and prodding the gem.  If I am misunderstanding key functions of the code, my apologies.  The change I'm proposing got the gem to work for my system.

Circuit Breaker says it does not work with standard "self" class methods.  But if the methods are grouped in a ClassMethod module, then the ClassMethod module can be used as an object for binding.  The only thing that gets in the way is the circuit state call to self.class.circuit_handler.new_circuit_state

This throws an error relating to calling class on a class. The instruction self.class.circuit_handler.new_circuit_state wil return a new Circuit state no matter what.

So by changing that instruction directly to CircuitBreaker::CircuitState.new the action can work on class method modules.
