### PR TITLE
Allow percentage failures

### DIFF
--- a/lib/circuit_breaker.rb
+++ b/lib/circuit_breaker.rb
@@ -109,3 +109,6 @@ end
 require 'circuit_breaker/circuit_handler'
 require 'circuit_breaker/circuit_broken_exception'
 require 'circuit_breaker/circuit_state'
+
+require 'circuit_breaker/trip_checker/count'
+require 'circuit_breaker/trip_checker/percentage'

--- a/lib/circuit_breaker/circuit_handler.rb
+++ b/lib/circuit_breaker/circuit_handler.rb
@@ -127,7 +127,7 @@ class CircuitBreaker::CircuitHandler
     @logger.debug("on_success: #{circuit_state.inspect}") if @logger
 
     if circuit_state.closed?
-      @logger.debug("on_success: reset_counts #{circuit_state.inspect}") if @logger
+      @logger.debug("on_success: reset_failure_count #{circuit_state.inspect}") if @logger
       circuit_state.reset_failure_count
     end
 

--- a/lib/circuit_breaker/circuit_handler.rb
+++ b/lib/circuit_breaker/circuit_handler.rb
@@ -11,7 +11,17 @@ class CircuitBreaker::CircuitHandler
   #
   # The number of failures needed to trip the breaker.
   #
-  attr_accessor :failure_threshold
+  attr_reader :failure_threshold
+
+  #
+  # The percentage of failures needed to trip the breaker.
+  #
+  attr_reader :failure_percentage_threshold
+
+  #
+  # The minimum number of calls required to trip a percentage checker.
+  #
+  attr_accessor :failure_percentage_minimum
 
   #
   # The period of time in seconds before attempting to reset the breaker.
@@ -33,17 +43,26 @@ class CircuitBreaker::CircuitHandler
   #
   attr_accessor :logger
 
-  DEFAULT_FAILURE_THRESHOLD  = 5
-  DEFAULT_FAILURE_TIMEOUT    = 5
-  DEFAULT_INVOCATION_TIMEOUT = 30
-  DEFAULT_EXCLUDED_EXCEPTIONS= []
+  #
+  # The object that determines whether or not the circuit has been tripped
+  #
+  attr_accessor :trip_checker
+
+  DEFAULT_FAILURE_THRESHOLD          = 5
+  DEFAULT_FAILURE_TIMEOUT            = 5
+  DEFAULT_INVOCATION_TIMEOUT         = 30
+  DEFAULT_EXCLUDED_EXCEPTIONS        = []
+  DEFAULT_FAILURE_PERCENTAGE_MINIMUM = 3
 
   def initialize(logger = nil)
     @logger = logger
-    @failure_threshold = DEFAULT_FAILURE_THRESHOLD
     @failure_timeout = DEFAULT_FAILURE_TIMEOUT
     @invocation_timeout = DEFAULT_INVOCATION_TIMEOUT
     @excluded_exceptions = DEFAULT_EXCLUDED_EXCEPTIONS
+
+    @failure_threshold = DEFAULT_FAILURE_THRESHOLD
+    @failure_percentage_minimum = DEFAULT_FAILURE_PERCENTAGE_MINIMUM
+    self.failure_threshold = failure_threshold
   end
 
   #
@@ -62,6 +81,7 @@ class CircuitBreaker::CircuitHandler
       on_circuit_open(circuit_state)
     end
 
+    circuit_state.increment_call_count
     begin
       out = nil
       Timeout.timeout(@invocation_timeout, CircuitBreaker::CircuitBrokenException) do
@@ -72,16 +92,6 @@ class CircuitBreaker::CircuitHandler
       on_failure(circuit_state) unless @excluded_exceptions.include?(e.class)
       raise
     end
-    return out
-  end
-
-  #
-  # Returns true when the number of failures is sufficient to trip the breaker, false otherwise.
-  #
-  def is_failure_threshold_reached(circuit_state)
-    out = (circuit_state.failure_count > failure_threshold)
-    @logger.debug("is_failure_threshold_reached: #{circuit_state.failure_count} > #{failure_threshold} == #{out}") if @logger
-
     return out
   end
 
@@ -117,7 +127,7 @@ class CircuitBreaker::CircuitHandler
     @logger.debug("on_success: #{circuit_state.inspect}") if @logger
 
     if circuit_state.closed?
-      @logger.debug("on_success: reset_failure_count #{circuit_state.inspect}") if @logger
+      @logger.debug("on_success: reset_counts #{circuit_state.inspect}") if @logger
       circuit_state.reset_failure_count
     end
 
@@ -135,7 +145,7 @@ class CircuitBreaker::CircuitHandler
 
     circuit_state.increment_failure_count
 
-    if is_failure_threshold_reached(circuit_state) || circuit_state.half_open?
+    if trip_checker.tripped?(circuit_state) || circuit_state.half_open?
       # Set us into a closed state.
       @logger.debug("on_failure: tripping circuit breaker #{circuit_state.inspect}") if @logger
       circuit_state.trip
@@ -151,4 +161,17 @@ class CircuitBreaker::CircuitHandler
     raise CircuitBreaker::CircuitBrokenException.new("Circuit broken, please wait for timeout", circuit_state)
   end
 
+  #
+  # Sets the trip checker to be a "count" checker with the specified value
+  #
+  def failure_threshold=(value)
+    @trip_checker = ::CircuitBreaker::TripChecker::Count.new(logger, value)
+  end
+
+  #
+  # Sets the trip checker to be a "percentage" checker with the specified value
+  #
+  def failure_percentage_threshold=(value)
+    @trip_checker = ::CircuitBreaker::TripChecker::Percentage.new(logger, value, failure_percentage_minimum)
+  end
 end

--- a/lib/circuit_breaker/circuit_state.rb
+++ b/lib/circuit_breaker/circuit_state.rb
@@ -41,11 +41,18 @@ class CircuitBreaker::CircuitState
   def initialize()
     @failure_count = 0
     @last_failure_time = nil
+    @call_count = 0
   end
 
   attr_accessor :last_failure_time
 
   attr_accessor :failure_count
+
+  attr_accessor :call_count
+
+  def increment_call_count
+    @call_count += 1
+  end
 
   def increment_failure_count
     @failure_count = @failure_count + 1
@@ -56,5 +63,8 @@ class CircuitBreaker::CircuitState
     @failure_count = 0
   end
 
+  def reset_counts
+    reset_failure_count
+    @call_count = 0
+  end
 end
-

--- a/lib/circuit_breaker/trip_checker/count.rb
+++ b/lib/circuit_breaker/trip_checker/count.rb
@@ -1,0 +1,18 @@
+module CircuitBreaker
+  module TripChecker
+    class Count
+      attr_accessor :logger, :threshold
+
+      def initialize(logger, threshold)
+        @logger    = logger
+        @threshold = threshold
+      end
+
+      def tripped?(circuit_state)
+        out = (circuit_state.failure_count > threshold)
+        logger.debug("tripped?: #{circuit_state.failure_count} > #{threshold} == #{out}") if logger
+        out
+      end
+    end
+  end
+end

--- a/lib/circuit_breaker/trip_checker/percentage.rb
+++ b/lib/circuit_breaker/trip_checker/percentage.rb
@@ -1,0 +1,21 @@
+module CircuitBreaker
+  module TripChecker
+    class Percentage
+      attr_accessor :logger, :threshold, :minimum
+
+      def initialize(logger, threshold, minimum = 3)
+        @logger    = logger
+        @threshold = threshold
+        @minimum   = minimum
+      end
+
+      def tripped?(circuit_state)
+        perc = circuit_state.failure_count.to_f / circuit_state.call_count
+        out  = (circuit_state.call_count > minimum) && (perc > threshold)
+
+        logger.debug("tripped?: #{circuit_state.call_count} > #{minimum} && #{perc} > #{threshold} == #{out}") if logger
+        out
+      end
+    end
+  end
+end

--- a/spec/circuit_breaker_spec.rb
+++ b/spec/circuit_breaker_spec.rb
@@ -86,6 +86,21 @@ describe CircuitBreaker do
     $stderr = orig_stderr
   end
 
+  it 'should create a percentage-based trip checker when those values are provided' do
+    TestClass.circuit_handler.failure_percentage_threshold = 0.5
+    @test_object = TestClass.new
+
+    5.times { @test_object.call_external_method }
+    @test_object.fail!
+    5.times { expect { @test_object.call_external_method }.to raise_error(RuntimeError) }
+
+    expect(@test_object.circuit_state.closed?).to be(true)
+    expect { @test_object.call_external_method }.to raise_error(RuntimeError)
+
+    expect(@test_object.circuit_state.open?).to be(true)
+    expect(@test_object.circuit_state.failure_count).to eq(6)
+  end
+
   describe "when closed" do
 
     it "should execute without failing" do

--- a/spec/trip_checker/count_spec.rb
+++ b/spec/trip_checker/count_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe CircuitBreaker::TripChecker::Count do
+  subject { CircuitBreaker::TripChecker::Count.new(nil, 3) }
+  StateDouble = Struct.new(:failure_count)
+
+  describe '#tripped?' do
+    it 'returns true if the value is over the threshold' do
+      state = StateDouble.new(4)
+      expect(subject.tripped?(state)).to be(true)
+    end
+
+    it 'returns false if the value is below the threshold' do
+      state = StateDouble.new(2)
+      expect(subject.tripped?(state)).to be(false)
+    end
+  end
+end

--- a/spec/trip_checker/percentage_spec.rb
+++ b/spec/trip_checker/percentage_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe CircuitBreaker::TripChecker::Percentage do
+  subject { CircuitBreaker::TripChecker::Percentage.new(nil, 0.5) }
+  StateDouble = Struct.new(:failure_count, :call_count)
+
+  describe '#tripped?' do
+    it 'returns true if the percentage is over the threshold' do
+      state = StateDouble.new(5, 10)
+      expect(subject.tripped?(state)).to be(false)
+
+      state.call_count = 9
+      expect(subject.tripped?(state)).to be(true)
+    end
+
+    it 'requires at least the minimum number of calls' do
+      state = StateDouble.new(0, 2)
+      expect(subject.tripped?(state)).to be(false)
+    end
+  end
+end


### PR DESCRIPTION
This breaks out the logic that determines if the circuit breaker is tripped into another class that responds to the `tripped?(circuit_state)` method. It then adds a percentage-based trip checker that will flip when a certain percentage of the given calls fail as opposed to a hard-coded number of failures.