### PR TITLE
make the gem work for class method

### DIFF
--- a/lib/circuit_breaker.rb
+++ b/lib/circuit_breaker.rb
@@ -64,7 +64,7 @@ module CircuitBreaker
   # you can have several instances of the same class with different states.
   #
   def circuit_state
-    @circuit_state ||= self.class.circuit_handler.new_circuit_state
+    @circuit_state ||= self.singleton_class.circuit_handler.new_circuit_state
   end
 
   module ClassMethods


### PR DESCRIPTION
Thanks for the nice gem.

The gem doesn't work properly now for class method like below.
It reports error like ```#<NoMethodError: undefined method `circuit_handler' for Class:Class>```

It's because of code ```self.class.circuit_handler```, which assumes```self``` here is one non-class object.

This PR is to fix this issue by changing ```self.class``` to ```slef.singleton_class```.

```
class A
  class << self
    def get
      ...
    end

    include CircuitBreaker
    circuit_method :get
  end
end
```