### PR TITLE
gemspec: Drop defunct property rubyforge_project

### DIFF
--- a/circuit_breaker.gemspec
+++ b/circuit_breaker.gemspec
@@ -49,8 +49,6 @@ Gem::Specification.new do |s|
        circuit_handler_class MyCustomCircuitHandler
      end}
 
-  s.rubyforge_project = %q{will_sargent}
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement. This PR removes that property.

## Background

* [RubyForge was closed down in 2013][1].
* rubygems/rubygems#2436 deprecated the `rubyforge_project` property

[1]: https://twitter.com/evanphx/status/399552820380053505
